### PR TITLE
Strengthen integer type check

### DIFF
--- a/exauq/core/designers.py
+++ b/exauq/core/designers.py
@@ -43,7 +43,7 @@ class SimpleDesigner(object):
             A batch of new simulator inputs.
         """
         check_int(
-            size, TypeError(f"Expected 'size' of type 'int' but received {type(size)}.")
+            size, TypeError(f"Expected 'size' to be an integer but received {type(size)}.")
         )
         if size < 0:
             raise ValueError(

--- a/exauq/utilities/validation.py
+++ b/exauq/utilities/validation.py
@@ -58,5 +58,5 @@ def check_finite(x: Any, exception: Exception) -> None:
 
 def check_int(x: Any, exception: Exception) -> None:
     """Raise the given exception if an object is not an int."""
-    if not isinstance(x, int):
+    if type(x) is not int:
         raise exception

--- a/tests/unit/test_designers.py
+++ b/tests/unit/test_designers.py
@@ -18,7 +18,7 @@ class TestSimpleDesigner(unittest.TestCase):
         size = 2.3
         with self.assertRaisesRegex(
             TypeError,
-            exact(f"Expected 'size' of type 'int' but received {type(size)}."),
+            exact(f"Expected 'size' to be an integer but received {type(size)}."),
         ):
             self.designer.make_design_batch(size)
 


### PR DESCRIPTION
As caught in review, check_int would not have raised an exception if a subclass of int was supplied (e.g. bool). Now an exception will be raised in such scenarios.