### PR TITLE
Fix CSV File BOM Handling Error in CLI Argument Parser

### DIFF
--- a/exauq/app/cli.py
+++ b/exauq/app/cli.py
@@ -54,7 +54,7 @@ class Cli(cmd2.Cmd):
     submit_parser.add_argument(
         "-f",
         "--file",
-        type=argparse.FileType(mode="r"),
+        type=argparse.FileType(mode="r", encoding="utf-8-sig"),
         help="A path to a csv file containing inputs to submit to the simulator.",
     )
 


### PR DESCRIPTION
Fixes an error when reading CSV files with BOM by updating file reading logic to use encoding="utf-8-sig", ensuring smooth conversion of strings to floats. Modified `submit_parser` in the `Cli` class to handle CSV files with and without BOM. Closes #225 