### PR TITLE
[Ready for Review] Issue 301: Update unit tests from deprecated

### DIFF
--- a/tests/unit/test_designers.py
+++ b/tests/unit/test_designers.py
@@ -2045,7 +2045,7 @@ class TestComputeMultiLevelLooSamples(ExauqTestCase):
         ) as mock_maximise:
             _ = self.compute_multi_level_loo_samples(seeds=seeds)
 
-        # checks {"seed": seeds[a]} is a subset of mock_maximise.call_args.kwargs[b]
+        # checks {"seed": seeds[a]} is a subset of mock_maximise.call_args[b].kwargs
         self.assertLessEqual(
             {"seed": seeds[1]}.items(), mock_maximise.call_args_list[0].kwargs.items()
         )


### PR DESCRIPTION
Closes iss #301 

Updated the deprecated `assertDictContainsSubset` to `assertLessEqual` alongside the `.items()` method as subsets in dictionaries can also be checked with less than logic. All in tests/unit/test_designers.py. 