### PR TITLE
[Ready for Review]Issue 302: Update workflow test python versions

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Install Poetry


### PR DESCRIPTION
Closes iss #302

Updated .github/workflows/test-package.yml python-versions for unit testing from 3.9, 3.10 and 3,11 up to 3.10, 3.11 and 3.12. 
