### PR TITLE
[ReadyforReview]Update workflow to run only approved reviews

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -13,7 +13,11 @@ on:
 
 jobs:
   job1:
-    if: github.event.review.state == 'approved'
+    if: ${{ github.event.review.state == 'approved' && 
+            (github.event.pull_request.base.ref == 'main' || 
+             github.event.pull_request.base.ref == 'dev' || 
+             startsWith(github.event.pull_request.base.ref, 'releases/')) 
+             }}
     name: Run unittest tests
     runs-on: ubuntu-latest
     strategy:
@@ -33,5 +37,3 @@ jobs:
       run: poetry install --with=dev
     - name: Run unit tests
       run: poetry run python -m unittest discover tests/
-
-      


### PR DESCRIPTION
Closes #348 

This workflow update should prevent the deadlock blockage but also save minutes by only running the unit test workflow after an approved review. Will firstly open as a draft PR to check that it doesn't run them immediately, then will open to review. 