### PR TITLE
[ReadyforReview]Iss377 update pyprojecttoml to pull down latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 authors = ["Exeter RSE Group"]
 description = "A toolbox for doing uncertainty quantification at the exascale"
 name = "exauq"
-version = "0.1.0"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"


### PR DESCRIPTION
Closes #377 

Moved dev branch pyproject.toml version to v0.2.0 to match that with planned release. 
