### PR TITLE
Fix CI workflow: Remove deprecated `--no-update` flag from Poetry lock command

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -33,8 +33,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: "poetry"
-    - name: Poetry lock no-update
-      run: poetry lock --no-update
+    - name: Poetry lock
+      run: poetry lock
     - name: Install dependencies
       run: poetry install --with=dev
     - name: Run unit tests


### PR DESCRIPTION
This PR fixes a CI workflow failure caused by the deprecated `--no-update` flag in the `poetry lock` command. As of Poetry 2.0, this option has been removed, and its behavior is the default. The flag has been removed from the workflow file to restore CI functionality. Closes #384 

**Changes Made:**
- Removed `--no-update` from the `poetry lock` command in `.github/workflows/test.yml`.

**Related Issue:**  
Closes #<issue-number> (replace with the actual issue number once created).

**Checklist:**
- [x] Removed the deprecated flag from the workflow.
- [x] Verified the CI workflow passes successfully.
- [x] Linked the PR to the related issue.

