### PR TITLE
Update README to Reflect Removal of `poetry shell` in Poetry 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ e.g. by creating a nested shell:
 ```bash
 poetry shell
 ```
+**Note:** As of [Poetry 2.0](https://python-poetry.org/blog/announcing-poetry-2.0.0/#poetry-export-and-poetry-shell-only-available-via-plugins),
+the `poetry shell` command has been removed. If you are using Poetry 2.0 or newer, please refer to the [official documentation](https://python-poetry.org/docs/managing-environments/#bash-csh-zsh)
+for guidance on managing virtual environments.
 
 Finally, to use the automatic pre-commit hooks designed for linting, run:
 


### PR DESCRIPTION

This PR updates the README to account for changes introduced in [Poetry 2.0](https://python-poetry.org/blog/announcing-poetry-2.0.0/#poetry-export-and-poetry-shell-only-available-via-plugins), specifically the removal of the `poetry shell` command. The changes include:  
- Adding a note about the removal of `poetry shell` for users on Poetry 2.0 and above.  
- Providing links to the official Poetry documentation for [managing environments](https://python-poetry.org/docs/managing-environments/#bash-csh-zsh).  
- Ensuring instructions remain clear for users on older versions of Poetry.  

**Motivation:**  
To prevent confusion for developers using Poetry 2.0+, as attempting to run `poetry shell` will result in an error. This update improves the onboarding experience and ensures the documentation is up to date with the latest tooling changes.

**Acceptance Criteria:**  
- [ ] The README clearly explains the removal of `poetry shell` in Poetry 2.0+.  
- [ ] Links to relevant sections of the Poetry documentation are functional and helpful.  
- [ ] The update maintains clarity for users of both older and newer Poetry versions.  

**Related Issue:**  
Closes #386.  
